### PR TITLE
Launch app shortcuts in a new window

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,6 +22,7 @@
                 ],
                 'launch' => [
                     'web_url' => $url,
+                    'container' => 'panel',
                 ],
             ],
             'permissions' => [


### PR DESCRIPTION
As per issue #1, we have decided to add the `container: panel` declaration in the extension `manifest.json` so that the app opens in its own window, and its own process.

It also appears with the designated icon in the Mac dock.

Closes #1.
